### PR TITLE
GitHub: add workflow to get funded grants list

### DIFF
--- a/.github/workflows/funded_grants_list.yml
+++ b/.github/workflows/funded_grants_list.yml
@@ -1,0 +1,49 @@
+name: Funded grants list
+
+on:
+  issues:
+    types: [opened, edited, labeled, unlabeled]
+
+jobs:
+  update-issues-file:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+
+    - name: Set up jq (for JSON processing)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y jq
+
+    - name: Get issues with funded label and store data in JSON
+      run: |
+        page=1
+        all_issues="[]"
+
+        while true; do
+          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                          -H "Accept: application/vnd.github.v3+json" \
+                          "https://api.github.com/repos/${{ github.repository }}/issues?labels=funded&state=all&per_page=100&page=$page")
+          if [ "$(echo $response | jq '. | length')" -eq 0 ]; then
+            break
+          fi
+          all_issues=$(echo $all_issues $response | jq -s '[.[][]]')
+          page=$((page + 1))
+        done
+
+        echo "$all_issues" > funded_grants_list_raw.json
+
+    - name: Extract useful data (title, url, labels, creation date and author)
+      run: |
+        jq '[.[] | {title: .title, url: .html_url, labels: [.labels[].name], created_at: .created_at, author: .user.login}]' funded_grants_list_raw.json > funded_grants_list.json
+
+    - name: Commit data to repository
+      run: |
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "actions@github.com"
+
+        git add funded_grants_list.json
+        git commit -m "Update funded grants list"
+        git push

--- a/.github/workflows/funded_grants_list.yml
+++ b/.github/workflows/funded_grants_list.yml
@@ -1,8 +1,8 @@
 name: Funded grants list
 
 on:
-  issues:
-    types: [opened, edited, labeled, unlabeled]
+  schedule:
+    - cron: '0 20 * * 0'  # Every Sunday at 8:00 PM UTC
 
 jobs:
   update-issues-file:
@@ -12,24 +12,19 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@v2
 
-    - name: Set up jq (for JSON processing)
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y jq
-
     - name: Get issues with funded label and store data in JSON
       run: |
         page=1
-        all_issues="[]"
+        all_issues=$(jq -n '[]')
 
         while true; do
-          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          response=$(curl -s \
                           -H "Accept: application/vnd.github.v3+json" \
                           "https://api.github.com/repos/${{ github.repository }}/issues?labels=funded&state=all&per_page=100&page=$page")
-          if [ "$(echo $response | jq '. | length')" -eq 0 ]; then
+          if [ "$(echo "$response" | jq 'length')" -eq 0 ]; then
             break
           fi
-          all_issues=$(echo $all_issues $response | jq -s '[.[][]]')
+          all_issues=$(jq -s '.[0] + .[1]' <(echo "$all_issues") <(echo "$response"))
           page=$((page + 1))
         done
 
@@ -37,13 +32,23 @@ jobs:
 
     - name: Extract useful data (title, url, labels, creation date and author)
       run: |
-        jq '[.[] | {title: .title, url: .html_url, labels: [.labels[].name], created_at: .created_at, author: .user.login}]' funded_grants_list_raw.json > funded_grants_list.json
+        jq '[.[] | {
+          title: .title,
+          url: .html_url,
+          labels: [.labels[].name],
+          created_at: .created_at,
+          author: .user.login
+        }]' funded_grants_list_raw.json > funded_grants_list.json
 
     - name: Commit data to repository
       run: |
         git config --global user.name "GitHub Actions"
         git config --global user.email "actions@github.com"
 
-        git add funded_grants_list.json
-        git commit -m "Update funded grants list"
-        git push
+        if git diff --quiet funded_grants_list.json; then
+          echo "No changes to commit."
+        else
+          git add funded_grants_list.json
+          git commit -m "Update funded grants list"
+          git push
+        fi


### PR DESCRIPTION
As part of the [Website project - Step 1](https://github.com/FreeCAD/FPA-grant-proposals/issues/40), for the `Donate` page, the list of funded grants is useful for showcasing projects where funds are directed.

This adds a simple workflow action that outputs a list with funded grants (issues having the `funded` label) and some basic data: title, url, labels, creation date and author.
Data will then be used by the website in a simple yet friendly manner (design still pending).

